### PR TITLE
Enable/Disable integration tests on configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,14 @@ install:
   - pip install --user cpp-coveralls
 
 script:
-  - docker network create --subnet=172.26.0.0/24 test
-  - docker run -d --net test --ip 172.26.0.2 --name zookeeper wurstmeister/zookeeper
-  - docker run -d --net test --ip 172.26.0.3 --name kafka -e KAFKA_ADVERTISED_HOST_NAME="172.26.0.3" -e KAFKA_ADVERTISED_PORT="9092" -e KAFKA_ZOOKEEPER_CONNECT="172.26.0.2:2181" -v /var/run/docker.sock:/var/run/docker.sock wurstmeister/kafka
-  - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka ./configure
+  - make setup-tests
+  - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka ./configure --enable-integration-tests
   - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka make
   - docker run -v $(pwd):/app -e CFLAGS=-w --link kafka --net test redborder/build-dockerfiles:n2kafka make tests
 
 after_success:
   - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka make clean
-  - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka ./configure --enable-coverage
+  - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka ./configure --enable-coverage --enable-integration-tests
   - docker run -v $(pwd):/app -e CFLAGS=-w --link kafka --net test redborder/build-dockerfiles:n2kafka make coverage
   - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka lcov --remove tests/coverage.info 'tests/*' '/usr/*' --output-file tests/coverage.info
   - docker run -v $(pwd):/app redborder/build-dockerfiles:n2kafka lcov --list tests/coverage.info

--- a/README.md
+++ b/README.md
@@ -43,3 +43,36 @@ behavior:
   * `"rdkafka.socket.keepalive.enable":"true"`
   * `"delivery.report.only.error":"true"`
 
+## Testing
+
+### Unit tests
+
+Run full unit tests suite:
+
+```bash
+make tests
+```
+
+This will run the full test suite, including Valgrind memory and threads
+checking. If no memory and threads checking is required, just run:
+
+```bash
+make checks
+```
+
+### Integration tests
+
+Integration tests involves some external services that should be running during
+testing: Kafka and Zookeeper. By default, integration tests
+are disabled due to this requirements and can be enabled through `configure`:
+
+```bash
+./configure --enable-integration-tests
+```
+
+Docker can be used to easily setup a basic testing environment:
+
+```bash
+make setup-tests # Set up a Kafka and Zookeeper in Docker
+make teardown-tests # Clean test environment
+```

--- a/configs_example/n2kafka_tests_http.json
+++ b/configs_example/n2kafka_tests_http.json
@@ -1,62 +1,71 @@
 {
-    "listeners": [{
-        "proto": "http",
-        "port": 2057,
-        "mode": "epoll",
-        "num_threads": 20,
-        "redborder_uri": true
-    }],
-    "brokers": "kafka",
-    "topic": "rb_flow",
-    "n2kafka_id": "n2kafka_test",
-    "rdkafka.socket.max.fails": "3",
-    "rdkafka.socket.keepalive.enable": "true",
-    "blacklist": ["192.168.101.3"],
-    "rb_http2k_config": {
-        "sensors_uuids": {
-            "abc": {
-                "enrichment": {
-                    "a": 1,
-                    "b": "c",
-                    "d": true,
-                    "e": null
-                },
-                "organization_uuid": "abc_org"
-            },
-            "def": {
-                "enrichment": {
-                    "f": 1,
-                    "g": "w",
-                    "h": false,
-                    "i": null
-                },
-                "organization_uuid": "def_org"
-            }
+  "listeners": [{
+    "proto": "http",
+    "port": 2057,
+    "mode": "epoll",
+    "num_threads": 20,
+    "redborder_uri": true,
+    "decode_as": "rb_http2k"
+  }],
+  "brokers": "172.26.0.3",
+  "n2kafka_id": "n2kafka_test",
+  "rdkafka.socket.max.fails": "3",
+  "rdkafka.socket.keepalive.enable": "true",
+  "blacklist": ["192.168.101.3"],
+  "rb_http2k_config": {
+    "sensors_uuids": {
+      "abc": {
+	"enrichment": {
+          "a": 1,
+          "b": "c",
+          "d": true,
+          "e": null
         },
-        "organizations_uuids": {
-            "abc_org": {
-                "enrichment": {
-                    "a_org": 10
-                },
-                "limits": {
-                    "bytes": 10240
-                }
-            },
-            "def_org": {
-                "enrichment": {
-                    "b_org": 20
-                },
-                "limits": {
-                    "bytes": 20480
-                }
-            }
+        "organization_uuid":"abc_org"
+      },
+      "def": {
+	"enrichment": {
+          "f": 1,
+          "g": "w",
+          "h": false,
+          "i": null
         },
-        "topics": {
-            "rb_flow": {
-                "partition_key": "client_mac",
-                "partition_algo": "mac"
-            },
-            "rb_event": {}
+        "organization_uuid":"def_org"
+      }
+    },
+    "organizations_uuids": {
+      "abc_org": {
+        "enrichment": {
+          "a_org":10
+        },
+        "limits": {
+          "bytes": 10240
         }
+      },
+      "def_org": {
+        "enrichment": {
+          "b_org":20
+        },
+        "limits": {
+          "bytes": 20480
+        }
+      }
+    },
+    "organizations_sync": {
+      "put_url": "http://localhost:80/",
+      "topics": ["rb_monitor","rb_event"],
+      "interval_s": 5,
+      "clean_on": {
+        "timestamp_s_mod":5,
+        "timestamp_s_offset":4
+      }
+    },
+    "topics": {
+      "rb_flow": {
+        "partition_key": "client_mac",
+        "partition_algo": "mac"
+      },
+      "rb_event": {}
     }
+  }
 }

--- a/configs_example/n2kafka_tests_tcp.json
+++ b/configs_example/n2kafka_tests_tcp.json
@@ -6,7 +6,7 @@
         "num_threads": 40,
         "max_time_threshold": 3600
     }],
-    "brokers": "kafka",
+    "brokers": "172.26.0.3",
     "topic": "rb_flow",
     "n2kafka_id": "n2kafka_test",
     "rdkafka.socket.max.fails": "3",

--- a/configure.n2kafka
+++ b/configure.n2kafka
@@ -23,6 +23,7 @@ mkl_mkvar_append CPPFLAGS CPPFLAGS "-Wmissing-declarations -Wdisabled-optimizati
 mkl_mkvar_append CPPFLAGS CPPFLAGS "-I. -I./src"
 
 mkl_toggle_option "Feature" WITH_HTTP "--enable-http" "HTTP support using libmicrohttpd" "y"
+mkl_toggle_option "Feature" WITH_INTEGRATION_TESTS "--enable-integration-tests" "Run integration tests" "n"
 mkl_toggle_option "Debug" WITH_COVERAGE "--enable-coverage" "Coverage build" "n"
 
 function checks_libmicrohttpd {
@@ -87,6 +88,10 @@ function checks {
     mkl_compile_check "curlversion" "" fail CC "" \
         "#include <curl/curl.h>
         static int foo __attribute__((unused)) = CURLMOPT_MAX_TOTAL_CONNECTIONS;"
+
+    if [[ "x$WITH_INTEGRATION_TESTS" == "xy" ]]; then
+      mkl_define_set "" "TESTS_KAFKA_HOST" "172.26.0.3"
+    fi
 
     if [[ "x$WITHOUT_OPTIMIZATION" != "xy" || "x$WITH_COVERAGE" != "xy" ]]; then
       mkl_mkvar_append CPPFLAGS CPPFLAGS "-DNDEBUG"

--- a/tests/integration_tests.h
+++ b/tests/integration_tests.h
@@ -1,0 +1,25 @@
+#include "../config.h"
+
+#include <curl/curl.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <zlib.h>
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+#ifdef TESTS_KAFKA_HOST
+#define SKIP_IF_NOT_INTEGRATION
+#else
+#define SKIP_IF_NOT_INTEGRATION                                                \
+  do {                                                                         \
+    skip();                                                                    \
+    return;                                                                    \
+  } while (0)
+#endif

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -75,8 +75,13 @@ for FILE in $*; do
     TIME=$(xml-printf '%s' $RESULT_XML ://testcase[$i]@time)
     NAME=$(xml-printf '%s' $RESULT_XML ://testcase[$i]@name)
     FAIL=$(xml-printf '%s' $RESULT_XML ://testcase[$i])
+    xml-printf '%s' $RESULT_XML ://testcase[$i]/skipped >/dev/null 2>&1
+    SKIPPED=${PIPESTATUS[0]}
 
-    if [ -z "$FAIL" ] && [ $MEM_ERRORS -eq 0 ] && [ $HELGRIND_ERRORS -eq 0 ] && [ $DRD_ERRORS -eq 0 ]; then
+    if [ "$SKIPPED" -eq 0 ]; then
+      # Skipped tests
+      printf "\t\e[90m ○ %s \e[0m(Skipped)\e[0m\n" "$NAME"
+    elif [ -z "$FAIL" ] && [ $MEM_ERRORS -eq 0 ] && [ $HELGRIND_ERRORS -eq 0 ] && [ $DRD_ERRORS -eq 0 ]; then
       # No errors at all
       printf "\t\e[32m ✔ %s \e[0m(%sms)\e[0m\n" "$NAME" "$TIME"
       ((SUCCESSES++))


### PR DESCRIPTION
Add a configure flag to enable or disable integration tests.

This is useful when the environment is not ready for run integration tests.
